### PR TITLE
Serializer test now creates json file in tmp directory

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,7 +1,7 @@
 from inflammation import models, serializers
 
 
-def test_patients_json_serializer():
+def test_patients_json_serializer(tmp_path):
     # Create some test data
     patients = [
         models.Patient('Alice', [models.Observation(i, i + 1) for i in range(3)]),
@@ -9,7 +9,7 @@ def test_patients_json_serializer():
     ]
 
     # Save and reload the data
-    output_file = 'patients.json'
+    output_file = tmp_path / 'patients.json'
     serializers.PatientJSONSerializer.save(patients, output_file)
     patients_new = serializers.PatientJSONSerializer.load(output_file)
 


### PR DESCRIPTION
patients.json is created in a temporary directory rather than the root directory
Using tmp_dir PathLib fixture provided by pytest